### PR TITLE
Add support for running and building in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust
+# build and run inside the container
+WORKDIR /usr/src/hyper_server_test
+COPY . .
+RUN cargo install --path .
+CMD [ "hyper_server_test" ]
+EXPOSE 8080/tcp
+
+

--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@ Messing around with hyper
 This is me messing around with code from *Hands-On Microservices With Rust* to explore Rust further, and the [hyper](http://hyper.rs) crate.
 
 You'd probably be better off looking at *Hands-On Microservices With Rust* unless you really like half-baked comments mixed in with your code.
+
+However, this builds and runs in a Docker container which is a neat change from the book.
+
+Run
+
+`docker build -t hyper_server_test .`
+
+then
+
+`docker run -it --rm -p 8000:8000 --name hyper-server-test-running hyper_server_test`
+
+to run it. Going to localhost:8000 should show you a white page saying "Rust Microservice FTW!!!!!!!!!!!!!!1111", which is nice.
+
+This will probably be replaced by something better, or used as a base for future projects.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     let builder = Server::bind(&addr);
     let server = builder.serve(|| {
         service_fn_ok(|_| {
-            Response::new(Body::from("Rust Microservice"))
+            Response::new(Body::from("Rust Microservice FTW!!!!!!!!!!!!!!1111"))
         })
     });
     let server = server.map_err(drop);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,15 @@ use hyper::{Body, Response, Server};
 use hyper::rt::Future;
 use hyper::service::service_fn_ok;
 
+// So far, so very basic, just runs and serves
+// text that says "Rust Microservices"
+// on localhost
+
 fn main() {
-    // So far, so very basic, just runs and serves
-    // text that says "Rust Microservices"
-    // on localhost
-    let addr = ([127, 0, 0, 1], 8080).into();
+    // wee fiddle required here to get the 
+    // it running in Docker, use 0.0.0.0:8080
+    // instead of 127.0.0.1 - won't bind if you use that
+    let addr = ([0, 0, 0, 0], 8000).into();
     let builder = Server::bind(&addr);
     let server = builder.serve(|| {
         service_fn_ok(|_| {


### PR DESCRIPTION
Server now runs at 0.0.0.0 to allow it to be compatible with Docker, and also now builds in the container instead.